### PR TITLE
Parameter values make assertion fail

### DIFF
--- a/test/cli/valik_test.cpp
+++ b/test/cli/valik_test.cpp
@@ -108,8 +108,8 @@ TEST_P(valik_search, search)
                                                          "--error ", std::to_string(number_of_errors),
                                                          "--index ", ibf_path(number_of_bins, window_size),
                                                          "--query ", data("query.fq"),
-							 "--tau 0.75",
-							 "--p_max 0.75");
+							 "--tau 1.0",
+							 "--p_max 1.0");
     EXPECT_EQ(result.exit_code, 0);
     EXPECT_EQ(result.out, std::string{});
     EXPECT_EQ(result.err, std::string{});

--- a/test/data/search/cli_test_output.sh
+++ b/test/data/search/cli_test_output.sh
@@ -2,8 +2,8 @@
 
 cd search
 
-tau=0.75
-p_max=0.75
+tau=1.0
+p_max=1.0
 
 for w in 19 23
 do


### PR DESCRIPTION
gcc10 result not shown:

```
[ RUN      ] search_suite/valik_search.search/8_bins_23_window_1_error_50_pattern_40_overlap
/home/evelin/metagenomics/valik/test/cli/valik_test.cpp:113: Failure
Expected equality of these values:
  result.exit_code
    Which is: 34304
  0
/home/evelin/metagenomics/valik/test/cli/valik_test.cpp:115: Failure
Expected equality of these values:
  result.err
    Which is: "valik: /home/evelin/metagenomics/valik/lib/raptor/src/threshold/precompute_threshold.cpp:135: std::vector<long unsigned int> raptor::threshold::precompute_threshold(const raptor::threshold::threshold_parameters&): Assertion `affected_minimisers <= number_of_minimisers' failed.\nAborted (core dumped)\n"
  std::string{}
    Which is: ""
```