### PR TITLE
[FIX] divide *all* queries over threads

### DIFF
--- a/include/valik/search/write_output_file_parallel.hpp
+++ b/include/valik/search/write_output_file_parallel.hpp
@@ -5,6 +5,8 @@
 #include <vector>
 
 #include <seqan3/search/dream_index/interleaved_bloom_filter.hpp>
+#include <seqan3/core/debug_stream.hpp>
+
 #include <valik/shared.hpp>
 #include <valik/search/local_prefilter.hpp>
 #include <valik/search/query_record.hpp>
@@ -29,7 +31,8 @@ inline void write_output_file_parallel(seqan3::interleaved_bloom_filter<ibf_data
     for (size_t i = 0; i < arguments.threads; ++i)
     {
         size_t const start = records_per_thread * i;
-        size_t const end = std::min(start + records_per_thread, num_records);
+        size_t const end = i == (arguments.threads - 1) ? num_records : records_per_thread * (i + 1);
+
         std::span<query_record const> records_slice{&records[start], &records[end]};
 
         /** This lambda writes the bin_hits into a file

--- a/test/cli/cli_test.hpp
+++ b/test/cli/cli_test.hpp
@@ -3,7 +3,6 @@
 #include <cstdlib>               // system calls
 #include <filesystem> // test directory creation
 #include <seqan3/test/expect_range_eq.hpp>
-#include <seqan3/core/debug_stream.hpp>
 #include <sstream>               // ostringstream
 #include <string>                // strings
 

--- a/test/cli/cli_test.hpp
+++ b/test/cli/cli_test.hpp
@@ -3,6 +3,7 @@
 #include <cstdlib>               // system calls
 #include <filesystem> // test directory creation
 #include <seqan3/test/expect_range_eq.hpp>
+#include <seqan3/core/debug_stream.hpp>
 #include <sstream>               // ostringstream
 #include <string>                // strings
 
@@ -95,6 +96,29 @@ protected:
 
 struct valik_base : public cli_test
 {
+    struct valik_match
+    {
+        std::string id;
+        std::unordered_set<uint16_t> matches;
+
+        valik_match(std::string query_id, std::unordered_set<uint16_t> match_set) : id(query_id), matches(match_set) {};
+
+        bool operator==(valik_match other)
+        {
+            if (id != other.id)
+                return false;
+
+            if (matches.size() != other.matches.size())
+                return false;
+
+            for (auto match : matches)
+                if (other.matches.count(match) == 0)
+                    return false;
+
+            return true;
+        }
+    };
+
     static inline std::filesystem::path const segment_metadata_path(size_t const overlap, size_t const bins) noexcept
     {
         std::string name{};
@@ -173,6 +197,51 @@ struct valik_base : public cli_test
         std::stringstream file_buffer;
         file_buffer << file_stream.rdbuf();
         return {file_buffer.str()};
+    }
+
+    static inline std::vector<valik_match> read_valik_output(std::filesystem::path const & path,
+                                                            std::ios_base::openmode const mode = std::ios_base::in)
+    {
+        std::vector<valik_match> valik_matches;
+        std::ifstream infile(path, mode);
+        std::string line;
+        while (std::getline(infile, line))
+        {
+            std::unordered_set<uint16_t> query_matches;
+
+            std::istringstream line_stream(line);
+            std::vector<std::string> cols;
+            std::string col;
+
+            while (std::getline(line_stream, col, '\t'))
+                cols.push_back(col);
+
+            EXPECT_TRUE(cols.size() > 0);
+            EXPECT_TRUE(cols.size() < 3);
+
+            if (cols.size() == 2)
+            {
+                std::istringstream match_stream(cols[1]);
+                std::string match;
+                while (std::getline(match_stream, match, ','))
+                    query_matches.insert(std::stoi(match));
+            }
+
+            valik_matches.push_back(valik_match(cols[0], query_matches));
+        }
+
+        return valik_matches;
+    }
+
+    static inline void const compare_search_out(std::vector<valik_match> expected,
+                                                std::vector<valik_match> actual)
+    {
+        EXPECT_EQ(expected.size(), actual.size());
+
+        for (auto match : expected)
+        {
+            EXPECT_TRUE(std::find(actual.begin(), actual.end(), match) != actual.end());
+        }
     }
 
     struct strong_bool

--- a/test/cli/valik_test.cpp
+++ b/test/cli/valik_test.cpp
@@ -154,11 +154,11 @@ TEST_P(valik_search_clusters, search)
     EXPECT_EQ(result.out, std::string{});
     EXPECT_EQ(result.err, std::string{});
 
-    std::string const expected = string_from_file(search_result_path(number_of_bins, window_size, number_of_errors,
+    auto expected = read_valik_output(search_result_path(number_of_bins, window_size, number_of_errors,
 			    pattern_size, overlap), std::ios::binary);
-    std::string const actual = string_from_file("search.out");
+    auto actual = read_valik_output("search.out");
 
-    EXPECT_EQ(expected, actual);
+    compare_search_out(expected, actual);
 }
 
 INSTANTIATE_TEST_SUITE_P(cluster_search_suite,
@@ -196,11 +196,11 @@ TEST_P(valik_search_segments, search)
     EXPECT_EQ(result.out, std::string{});
     EXPECT_EQ(result.err, std::string{});
 
-    std::string const expected = string_from_file(search_result_path(segment_overlap, number_of_bins, window_size, number_of_errors,
+    auto expected = read_valik_output(search_result_path(segment_overlap, number_of_bins, window_size, number_of_errors,
 			    pattern_size, overlap), std::ios::binary);
-    std::string const actual = string_from_file("search.out");
+    auto actual = read_valik_output("search.out");
 
-    EXPECT_EQ(expected, actual);
+    compare_search_out(expected, actual);
 }
 
 INSTANTIATE_TEST_SUITE_P(segment_search_suite,

--- a/test/cli/valik_test.cpp
+++ b/test/cli/valik_test.cpp
@@ -148,6 +148,7 @@ TEST_P(valik_search_clusters, search)
                                                         "--error ", std::to_string(number_of_errors),
                                                         "--index ", ibf_path(number_of_bins, window_size),
                                                         "--query ", data("query.fq"),
+                                                        "--threads 3",
 							                            "--tau 0.75",
 							                            "--p_max 0.75");
     EXPECT_EQ(result.exit_code, 0);
@@ -190,6 +191,7 @@ TEST_P(valik_search_segments, search)
                                                         "--error ", std::to_string(number_of_errors),
                                                         "--index ", ibf_path(segment_overlap, number_of_bins, window_size),
                                                         "--query ", data("single_query.fq"),
+                                                        "--threads 3",
 							                            "--tau 0.75",
 							                            "--p_max 0.25");
     EXPECT_EQ(result.exit_code, 0);


### PR DESCRIPTION
The last queries of the query file were not processed in case the queries could not be divided over the reads exactly ( nr_of_queries % nr_of_threads != 0).
Test parallel search (parallel IBF building requires larger dataset of >= 64 bins)