### PR TITLE
Search output as unordered set of bin numbers

### DIFF
--- a/include/valik/search/write_output_file_parallel.hpp
+++ b/include/valik/search/write_output_file_parallel.hpp
@@ -2,7 +2,6 @@
 
 #include <chrono>
 #include <thread>
-#include <vector>
 
 #include <seqan3/search/dream_index/interleaved_bloom_filter.hpp>
 #include <seqan3/core/debug_stream.hpp>
@@ -39,7 +38,7 @@ inline void write_output_file_parallel(seqan3::interleaved_bloom_filter<ibf_data
          *
          * Caution, it creates a `result_string` of type `std::string` which it reuses for more efficiency
          */
-        auto result_cb = [&, result_string=std::string{}](std::string const& id, std::set<size_t> const& bin_hits) mutable
+        auto result_cb = [&, result_string=std::string{}](std::string const& id, std::unordered_set<size_t> const& bin_hits) mutable
         {
             result_string.clear();
             result_string += id;


### PR DESCRIPTION
Testing on 10Mb IBF and 3MB of queries showed an 5% in runtime when using an `std::unordered_set`

```
Time (sec) Memory (bytes) Version
1.42    21000        Set
1.41    21056        Set
1.41    20884        Set
1.34    20904        Unordered set
1.34    20956        Unordered set
1.36    21036        Unordered set
```