### PR TITLE
fix: return error code on failed search

### DIFF
--- a/src/argument_parsing/search.cpp
+++ b/src/argument_parsing/search.cpp
@@ -148,8 +148,8 @@ void run_search(seqan3::argument_parser & parser)
     // ==========================================
     // Set default pattern size.
     // ==========================================
-	if (!arguments.pattern_size)
-	{
+    if (!arguments.pattern_size)
+    {
         seqan3::sequence_file_input<dna4_traits, seqan3::fields<seqan3::field::seq>> query_in{arguments.query_file};
         for (auto & [seq] : query_in | std::views::take(1))
         {
@@ -163,7 +163,7 @@ void run_search(seqan3::argument_parser & parser)
 
     if (parser.is_option_set("overlap"))
     {
-	    if (arguments.overlap >= arguments.pattern_size)
+        if (arguments.overlap >= arguments.pattern_size)
                 throw seqan3::argument_parser_error{"The overlap size has to be smaller than the pattern size."};
     }
     else

--- a/src/valik_main.cpp
+++ b/src/valik_main.cpp
@@ -28,9 +28,14 @@ int main(int argc, char ** argv)
         if (sub_parser.info.app_name == std::string_view{"valik-consolidate"})
             valik::app::run_consolidation(sub_parser);
     }
-    catch (seqan3::argument_parser_error const & ext)
+    catch(std::exception const& e)
     {
-        std::cerr << "[Error] " << ext.what() << '\n';
+        std::cerr << "[Error] " << e.what() << '\n';
+        std::exit(-1);
+    }
+    catch(...)
+    {
+        std::cerr << "[Error] unknown exception type\n";
         std::exit(-1);
     }
 

--- a/src/valik_search.cpp
+++ b/src/valik_search.cpp
@@ -81,6 +81,11 @@ bool run_program(search_arguments const &arguments, search_time_statistics & tim
     if (auto ptr = std::getenv("VALIK_STELLAR"); ptr != nullptr)
         stellar_exec = std::string(ptr);
 
+    std::string merge_exec = "cat";
+    if (auto ptr = std::getenv("VALIK_MERGE"); ptr != nullptr)
+        merge_exec = std::string(ptr);
+
+
     sync_out synced_out{arguments.out_file};
     auto queue = cart_queue<query_record>{index.ibf().bin_count(), arguments.cart_max_capacity, arguments.max_queued_carts};
 
@@ -183,7 +188,7 @@ bool run_program(search_arguments const &arguments, search_time_statistics & tim
     queue.finish(); // Flush carts that are not empty yet
     consumerThreads.clear();
 
-    std::vector<std::string> merge_process_args{"cat"};
+    std::vector<std::string> merge_process_args{merge_exec};
     for (auto & path : output_files)
         merge_process_args.push_back(path);
     external_process merge(merge_process_args);

--- a/test/cli/cli_test.hpp
+++ b/test/cli/cli_test.hpp
@@ -156,7 +156,7 @@ struct valik_base : public cli_test
     }
 
     static std::filesystem::path search_result_path(size_t const number_of_bins, size_t const window_size,
-		    size_t const number_of_errors, size_t const pattern_size, size_t const overlap) noexcept
+            size_t const number_of_errors, size_t const pattern_size, size_t const overlap) noexcept
     {
         std::string name{};
         name += std::to_string(number_of_bins);
@@ -174,7 +174,7 @@ struct valik_base : public cli_test
     }
 
     static std::filesystem::path search_result_path(size_t const segment_overlap, size_t const number_of_bins, size_t const window_size,
-		    size_t const number_of_errors, size_t const pattern_size, size_t const overlap) noexcept
+            size_t const number_of_errors, size_t const pattern_size, size_t const overlap) noexcept
     {
         std::string name{};
         name += std::to_string(segment_overlap);
@@ -536,7 +536,7 @@ struct valik_split : public valik_base, public testing::WithParamInterface<std::
 struct valik_build_clusters : public valik_base, public testing::WithParamInterface<std::tuple<size_t, size_t, bool>> {};
 struct valik_build_segments : public valik_base, public testing::WithParamInterface<std::tuple<size_t, size_t, size_t>> {};
 struct valik_search_clusters : public valik_base, public testing::WithParamInterface<std::tuple<size_t, size_t, size_t,
-	size_t, size_t>> {};
+    size_t, size_t>> {};
 struct valik_search_segments : public valik_base, public testing::WithParamInterface<std::tuple<size_t, size_t, size_t, size_t,
-	size_t, size_t>> {};
+    size_t, size_t>> {};
 struct valik_consolidate : public valik_base, public testing::WithParamInterface<std::tuple<size_t, size_t>> {};

--- a/test/cli/valik_options_test.cpp
+++ b/test/cli/valik_options_test.cpp
@@ -21,8 +21,8 @@ TEST_F(argparse, no_options)
     std::string const expected
     {
         "valik - Pre-filter for querying databases of nucleotide sequences for approximate local matches.\n"
-	    "================================================================================================\n"
-	    "    Try -h or --help for more information.\n"
+        "================================================================================================\n"
+        "    Try -h or --help for more information.\n"
     };
     EXPECT_EQ(result.exit_code, 0);
     EXPECT_EQ(result.out, expected);
@@ -35,8 +35,8 @@ TEST_F(argparse_split, no_options)
     std::string const expected
     {
         "valik - Pre-filter for querying databases of nucleotide sequences for approximate local matches.\n"
-	    "================================================================================================\n"
-	    "    Try -h or --help for more information.\n"
+        "================================================================================================\n"
+        "    Try -h or --help for more information.\n"
     };
     EXPECT_EQ(result.exit_code, 0);
     EXPECT_EQ(result.out, expected);
@@ -49,8 +49,8 @@ TEST_F(argparse_build, no_options)
     std::string const expected
     {
         "valik - Pre-filter for querying databases of nucleotide sequences for approximate local matches.\n"
-	    "================================================================================================\n"
-	    "    Try -h or --help for more information.\n"
+        "================================================================================================\n"
+        "    Try -h or --help for more information.\n"
     };
     EXPECT_EQ(result.exit_code, 0);
     EXPECT_EQ(result.out, expected);
@@ -63,8 +63,8 @@ TEST_F(argparse_search, no_options)
     std::string const expected
     {
         "valik - Pre-filter for querying databases of nucleotide sequences for approximate local matches.\n"
-	    "================================================================================================\n"
-	    "    Try -h or --help for more information.\n"
+        "================================================================================================\n"
+        "    Try -h or --help for more information.\n"
     };
     EXPECT_EQ(result.exit_code, 0);
     EXPECT_EQ(result.out, expected);
@@ -291,7 +291,7 @@ TEST_F(argparse_search, pattern_window)
                                                          "--query ", data("query.fq"),
                                                          "--index ", data("8bins19window.ibf"),
                                                          "--output search.gff",
-							                             "--pattern 12");
+                                                         "--pattern 12");
     EXPECT_NE(result.exit_code, 0);
     EXPECT_EQ(result.out, std::string{});
     EXPECT_EQ(result.err, std::string{"[Error] The minimiser window cannot be bigger than the pattern.\n"});

--- a/test/cli/valik_test.cpp
+++ b/test/cli/valik_test.cpp
@@ -141,6 +141,7 @@ TEST_P(valik_search_clusters, search)
 
     setup_tmp_dir();
     setenv("VALIK_STELLAR", "echo", true);
+    setenv("VALIK_MERGE", "echo", true);
 
     if (window_size == 23 && number_of_errors == 0)
         GTEST_SKIP() << "Needs dynamic threshold correction";
@@ -190,6 +191,7 @@ TEST_P(valik_search_segments, search)
 
     setup_tmp_dir();
     setenv("VALIK_STELLAR", "echo", true);
+    setenv("VALIK_MERGE", "echo", true);
 
     cli_test_result const result = execute_app("valik", "search",
                                                         "--output search.gff",

--- a/test/cli/valik_test.cpp
+++ b/test/cli/valik_test.cpp
@@ -57,9 +57,9 @@ TEST_P(valik_build_clusters, build_from_clusters)
 
     {
         std::ofstream file{"bin_paths.txt"};
-	for (size_t i{0}; i < number_of_bins; i++)
+    for (size_t i{0}; i < number_of_bins; i++)
         {
-	    std::string file_path = cli_test::data("bin_" + std::to_string(i) + ".fasta");
+        std::string file_path = cli_test::data("bin_" + std::to_string(i) + ".fasta");
             file << file_path << '\n';
         }
         file << '\n';
@@ -149,19 +149,19 @@ TEST_P(valik_search_clusters, search)
     cli_test_result const result = execute_app("valik", "search",
                                                         "--output search.gff",
                                                         "--pattern", std::to_string(pattern_size),
-							                            "--overlap", std::to_string(overlap),
+                                                        "--overlap", std::to_string(overlap),
                                                         "--error ", std::to_string(number_of_errors),
                                                         "--index ", ibf_path(number_of_bins, window_size),
                                                         "--query ", data("query.fq"),
                                                         "--threads 1",
-							                            "--tau 0.75",
-							                            "--p_max 0.75");
+                                                        "--tau 0.75",
+                                                        "--p_max 0.75");
     EXPECT_EQ(result.exit_code, 0);
     EXPECT_EQ(result.out, std::string{});
     EXPECT_EQ(result.err, std::string{});
 
     auto expected = string_list_from_file(search_result_path(number_of_bins, window_size, number_of_errors,
-			    pattern_size, overlap), std::ios::binary);
+                pattern_size, overlap), std::ios::binary);
     auto actual = string_list_from_file("search.gff.out");
 
     EXPECT_EQ(expected, actual);
@@ -170,14 +170,14 @@ TEST_P(valik_search_clusters, search)
 INSTANTIATE_TEST_SUITE_P(cluster_search_suite,
                          valik_search_clusters,
                          testing::Combine(testing::Values(8), testing::Values(19, 23), testing::Values(0, 1),
-				 testing::Values(50, 100), testing::Values(1, 40)),
+                 testing::Values(50, 100), testing::Values(1, 40)),
                          [] (testing::TestParamInfo<valik_search_clusters::ParamType> const & info)
                          {
                              std::string name = std::to_string(std::get<0>(info.param)) + "_bins_" +
                                                 std::to_string(std::get<1>(info.param)) + "_window_" +
                                                 std::to_string(std::get<2>(info.param)) + "_error_" +
-						                        std::to_string(std::get<3>(info.param)) + "_pattern_" +
-						                        std::to_string(std::get<4>(info.param)) + "_overlap";
+                                                std::to_string(std::get<3>(info.param)) + "_pattern_" +
+                                                std::to_string(std::get<4>(info.param)) + "_overlap";
                              return name;
                          });
 
@@ -196,20 +196,20 @@ TEST_P(valik_search_segments, search)
     cli_test_result const result = execute_app("valik", "search",
                                                         "--output search.gff",
                                                         "--pattern", std::to_string(pattern_size),
-							                            "--overlap", std::to_string(overlap),
+                                                        "--overlap", std::to_string(overlap),
                                                         "--error ", std::to_string(number_of_errors),
                                                         "--index ", ibf_path(segment_overlap, number_of_bins, window_size),
                                                         "--query ", data("single_query.fq"),
-							                            "--tau 0.75",
+                                                        "--tau 0.75",
                                                         "--threads 1",
                                                         "--seg-path", segment_metadata_path(segment_overlap, number_of_bins),
-							                            "--p_max 0.25");
+                                                        "--p_max 0.25");
     EXPECT_EQ(result.exit_code, 0);
     EXPECT_EQ(result.out, std::string{});
     EXPECT_EQ(result.err, std::string{});
 
     auto expected = string_list_from_file(search_result_path(segment_overlap, number_of_bins, window_size, number_of_errors,
-			    pattern_size, overlap), std::ios::binary);
+                pattern_size, overlap), std::ios::binary);
     auto actual = string_list_from_file("search.gff.out");
 
     EXPECT_EQ(expected, actual);
@@ -224,8 +224,8 @@ INSTANTIATE_TEST_SUITE_P(segment_search_suite,
                              std::string name = std::to_string(std::get<1>(info.param)) + "_bins_" +
                                                 std::to_string(std::get<2>(info.param)) + "_window_" +
                                                 std::to_string(std::get<3>(info.param)) + "_error_" +
-						                        std::to_string(std::get<4>(info.param)) + "_pattern_" +
-						                        std::to_string(std::get<5>(info.param)) + "_overlap";
+                                                std::to_string(std::get<4>(info.param)) + "_pattern_" +
+                                                std::to_string(std::get<5>(info.param)) + "_overlap";
                              return name;
                          });
 
@@ -261,6 +261,6 @@ INSTANTIATE_TEST_SUITE_P(consolidation_suite,
                          [] (testing::TestParamInfo<valik_consolidate::ParamType> const & info)
                          {
                              std::string name = std::to_string(std::get<0>(info.param)) + "_bins_" +
-						                        std::to_string(std::get<1>(info.param)) + "_overlap";
+                                                std::to_string(std::get<1>(info.param)) + "_overlap";
                              return name;
                          });

--- a/test/data/search/cli_test_output.sh
+++ b/test/data/search/cli_test_output.sh
@@ -24,8 +24,8 @@ do
                 echo "Potential matches overlap by $o bp"
                 output="8bins"$w"window"$e"error"$p"pattern"$o"overlap.gff"
                 valik search --index ../build/8bins${w}window.ibf --query query.fq --output "$output" --error "$e" --pattern "$p" --overlap "$o" --tau "$tau" --p_max "$p_max" --threads 1
-	        rm "$output"
-		done
+            rm "$output"
+        done
         done
     done
 done

--- a/test/data/split/cli_test_output.sh
+++ b/test/data/split/cli_test_output.sh
@@ -64,8 +64,8 @@ do
         echo "Searching IBF with $errors errors"
         search_out="single/"$seg_overlap"overlap"$b"bins"$w"window"$errors"errors.gff"
         valik search --index "$index" --query "$query" --output "$search_out" --error "$errors" --pattern "$pattern" --overlap "$pat_overlap" --tau "$tau" --p_max "$p_max" --seg-path "$seg_meta" --threads 1
-	rm "$search_out"
-	done
+    rm "$search_out"
+    done
 done
 
 # avoid creating multiple identical reference metadata output files


### PR DESCRIPTION
This print additional information if a run failed because VALIK_STELLAR executable didn't return without error.

This will produce an output:
```
error running VALIK_STELLAR
call: stellar bin_4.fasta /tmp/valik/stellar_call_Tk8Gtz/query_4_1.fasta -e 0.000010 -l 50 -o /tmp/valik/stellar_call_Tk8Gtz/query_4_1.fasta.gff
Failed to open database file.

Merging failed
[Error] valik_search failed. Run didn't complete correctly. 
```
and `echo $?` will be `255`
