### PR TITLE
fix: return status in external_process is now parsed correctly

### DIFF
--- a/include/utilities/external_process.hpp
+++ b/include/utilities/external_process.hpp
@@ -133,7 +133,7 @@ private:
         auto t2 = std::jthread{[&] { readUntilEnd(stderrpipe[READ_END], stdcerr); }};
 
         waitpid(pid, &status_, 0); /* wait for child to exit */
-        status_ = status_ >> 8;
+        status_ = WEXITSTATUS(status_);
         close(stdoutpipe[WRITE_END]);
         close(stderrpipe[WRITE_END]);
     }


### PR DESCRIPTION
Parsing the return status can't just be done by shifting 8bits, but must also be masked with 0xff.
The correct way of doing it, is using "WEXITSTATUS" which does exactly this.