### PR TITLE
Read reference metadata 

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@
 [4]: https://codecov.io/gh/eaasna/valik
 
 ## Quick run: split and search single reference sequence
-`valik split test/data/split/single_reference.fasta --reference-output reference_metadata.txt --segment-output segment_metadata.txt --bins 4`
+`valik split test/data/split/single_reference.fasta --ref-meta reference_metadata.txt --seg-meta segment_metadata.txt --bins 4`
 
-`valik build --from-segments test/data/split/single_reference.fasta --seg-path segment_metadata.txt --ref-meta reference_metadata.txt --window 15 --kmer 13 --output seg_file_index.ibf --size 100k`
+`valik build --from-segments test/data/split/single_reference.fasta --seg-meta segment_metadata.txt --ref-meta reference_metadata.txt --window 15 --kmer 13 --output seg_file_index.ibf --size 100k`
 
-`valik search --index seg_file_index.ibf --threads 4 --query test/data/search/query.fq --pattern 50 --overlap 49 --error 1 --output search.gff --seg-path segment_metadata.txt`
-`valik consolidate --input search.gff --meta-path reference_metadata.txt --output consolidated.gff`
+`valik search --index seg_file_index.ibf --threads 4 --query test/data/search/query.fq --pattern 50 --overlap 49 --error 1 --output search.gff --seg-meta segment_metadata.txt`
+`valik consolidate --input search.gff --ref-meta reference_metadata.txt --output consolidated.gff`
 ```text
 read-0  0,
 read-1  0,

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@
 `valik build --from-segments test/data/split/single_reference.fasta --seg-meta segment_metadata.txt --ref-meta reference_metadata.txt --window 15 --kmer 13 --output seg_file_index.ibf --size 100k`
 
 `valik search --index seg_file_index.ibf --threads 4 --query test/data/search/query.fq --pattern 50 --overlap 49 --error 1 --output search.gff --seg-meta segment_metadata.txt`
+
 `valik consolidate --input search.gff --ref-meta reference_metadata.txt --output consolidated.gff`
+
 ```text
 read-0  0,
 read-1  0,

--- a/include/valik/shared.hpp
+++ b/include/valik/shared.hpp
@@ -115,6 +115,7 @@ struct search_arguments
 
     bool call_stellar{false};
     std::filesystem::path seg_path{};
+    std::filesystem::path ref_meta_path{};
 };
 
 } // namespace valik

--- a/src/argument_parsing/build.cpp
+++ b/src/argument_parsing/build.cpp
@@ -54,7 +54,7 @@ void init_build_parser(seqan3::argument_parser & parser, build_arguments & argum
                     seqan3::option_spec::standard);
     parser.add_option(arguments.seg_path,
                     '\0',
-                    "seg-path",
+                    "seg-meta",
                     "Path to segment metadata file created by split.",
                     seqan3::option_spec::standard,
                     seqan3::input_file_validator{});

--- a/src/argument_parsing/consolidate.cpp
+++ b/src/argument_parsing/consolidate.cpp
@@ -15,7 +15,7 @@ void init_consolidation_parser(seqan3::argument_parser & parser, consolidation_a
                       seqan3::input_file_validator{{"gff"}});
     parser.add_option(arguments.ref_meta_path,
                     '\0',
-                    "meta-path",
+                    "ref-meta",
                     "Path to reference metadata file created by split.",
                     seqan3::option_spec::standard,
                     seqan3::input_file_validator{});

--- a/src/argument_parsing/search.cpp
+++ b/src/argument_parsing/search.cpp
@@ -94,9 +94,15 @@ void init_search_parser(seqan3::argument_parser & parser, search_arguments & arg
                     "call-stellar",
                     "Call distributed stellar search.",
                     seqan3::option_spec::standard);
+    parser.add_option(arguments.ref_meta_path,
+                    '\0',
+                    "ref-meta",
+                    "Path to reference metadata file created by split.",
+                    seqan3::option_spec::standard,
+                    seqan3::input_file_validator{});
     parser.add_option(arguments.seg_path,
                     '\0',
-                    "seg-path",
+                    "seg-meta",
                     "Path to segment metadata file created by split.",
                     seqan3::option_spec::standard,
                     seqan3::input_file_validator{});

--- a/src/argument_parsing/split.cpp
+++ b/src/argument_parsing/split.cpp
@@ -14,13 +14,13 @@ void init_split_parser(seqan3::argument_parser & parser, split_arguments & argum
                       seqan3::input_file_validator{});
     parser.add_option(arguments.ref_out,
                       '\0',
-                      "reference-output",
+                      "ref-meta",
                       "Please provide a valid path to the reference metadata output.",
                       seqan3::option_spec::required,
                       seqan3::output_file_validator{seqan3::output_file_open_options::open_or_create});
     parser.add_option(arguments.seg_out,
                       '\0',
-                      "segment-output",
+                      "seg-meta",
                       "Please provide a valid path to the segment metadata output.",
                       seqan3::option_spec::required,
                       seqan3::output_file_validator{seqan3::output_file_open_options::open_or_create});

--- a/test/cli/valik_options_test.cpp
+++ b/test/cli/valik_options_test.cpp
@@ -100,8 +100,8 @@ TEST_F(argparse, unknown_option)
 TEST_F(argparse_split, input_missing)
 {
     cli_test_result const result = execute_app("valik", "split",
-                                                         "--segment-output seg",
-                                                         "--reference-output ref");
+                                                         "--seg-meta seg",
+                                                         "--ref-meta ref");
     EXPECT_NE(result.exit_code, 0);
     EXPECT_EQ(result.out, std::string{});
     EXPECT_EQ(result.err, std::string{"[Error] Not enough positional arguments provided (Need at least 1). See -h/--help for more information.\n"});
@@ -111,8 +111,8 @@ TEST_F(argparse_split, input_invalid)
 {
     cli_test_result const result = execute_app("valik", "split",
                                                          "nonexistent",
-                                                         "--segment-output seg",
-                                                         "--reference-output ref");
+                                                         "--seg-meta seg",
+                                                         "--ref-meta ref");
     EXPECT_NE(result.exit_code, 0);
     EXPECT_EQ(result.out, std::string{});
     EXPECT_EQ(result.err, std::string{"[Error] Validation failed for positional option 1: The file \"nonexistent\" does not exist!\n"});
@@ -122,8 +122,8 @@ TEST_F(argparse_split, no_bins)
 {
     cli_test_result const result = execute_app("valik", "split",
                                                          "dummy.fasta",
-                                                         "--segment-output seg",
-                                                         "--reference-output ref",
+                                                         "--seg-meta seg",
+                                                         "--ref-meta ref",
                                                          "--bins 0");
     EXPECT_NE(result.exit_code, 0);
     EXPECT_EQ(result.out, std::string{});

--- a/test/cli/valik_test.cpp
+++ b/test/cli/valik_test.cpp
@@ -18,8 +18,8 @@ TEST_P(valik_split, split)
                                                          data("various_chromosome_lengths.fasta"),
                                                          "--overlap ", std::to_string(overlap),
                                                          "--bins ", std::to_string(bins),
-                                                         "--reference-output reference_metadata.txt",
-                                                         "--segment-output reference_segments.txt");
+                                                         "--ref-meta reference_metadata.txt",
+                                                         "--seg-meta reference_segments.txt");
     EXPECT_EQ(result.exit_code, 0);
     EXPECT_EQ(result.out, std::string{});
     EXPECT_EQ(result.err, std::string{"Reference sequence: chr5 is too short and will be skipped.\n"});
@@ -110,7 +110,7 @@ TEST_P(valik_build_segments, build_from_segments)
                                                          "--output index.ibf",
                                                          "--from-segments",
                                                          "--ref-meta", ref_meta_path,
-                                                         "--seg-path", seg_meta_path,
+                                                         "--seg-meta", seg_meta_path,
                                                          seg_input);
     EXPECT_EQ(result.exit_code, 0);
     EXPECT_EQ(result.out, std::string{});
@@ -202,7 +202,7 @@ TEST_P(valik_search_segments, search)
                                                         "--query ", data("single_query.fq"),
                                                         "--tau 0.75",
                                                         "--threads 1",
-                                                        "--seg-path", segment_metadata_path(segment_overlap, number_of_bins),
+                                                        "--seg-meta", segment_metadata_path(segment_overlap, number_of_bins),
                                                         "--p_max 0.25");
     EXPECT_EQ(result.exit_code, 0);
     EXPECT_EQ(result.out, std::string{});
@@ -242,7 +242,7 @@ TEST_P(valik_consolidate, consolidation)
 
     cli_test_result const result = execute_app("valik", "consolidate",
                                                         "--input ", consolidation_input_path(number_of_bins, segment_overlap),
-                                                        "--meta-path", ref_meta_path,
+                                                        "--ref-meta", ref_meta_path,
                                                         "--output consolidated.gff");
 
     EXPECT_EQ(result.exit_code, 0);

--- a/test/cli/valik_test.cpp
+++ b/test/cli/valik_test.cpp
@@ -202,6 +202,7 @@ TEST_P(valik_search_segments, search)
                                                         "--query ", data("single_query.fq"),
                                                         "--tau 0.75",
                                                         "--threads 1",
+                                                        "--ref-meta", data("reference_metadata.txt"),
                                                         "--seg-meta", segment_metadata_path(segment_overlap, number_of_bins),
                                                         "--p_max 0.25");
     EXPECT_EQ(result.exit_code, 0);

--- a/test/data/consolidate/cli_test_output.sh
+++ b/test/data/consolidate/cli_test_output.sh
@@ -9,7 +9,7 @@ do
     for minLen in 50
     do
         valik consolidate --input ${bin}bins${minLen}overlap_dream_all.gff \
-                                             --meta-path ${bin}bins${minLen}overlap_reference_metadata.tsv \
+                                             --ref-meta ${bin}bins${minLen}overlap_reference_metadata.tsv \
                                              --output ${bin}bins${minLen}overlap_dream_consolidated.gff
     done
 done

--- a/test/data/create_output.sh
+++ b/test/data/create_output.sh
@@ -9,6 +9,7 @@ fi
 
 export VALIK_TMP=tmp/valik/my_dir
 export VALIK_STELLAR=echo
+export VALIK_MERGE=echo
 
 echo "### Running valik split ###"
 ./split/cli_test_output.sh

--- a/test/data/datasources.cmake
+++ b/test/data/datasources.cmake
@@ -15,13 +15,13 @@ declare_datasource (FILE various_chromosome_lengths.fasta
 
 declare_datasource (FILE 150overlap16bins13window1errors.gff.out
                 URL ${CMAKE_SOURCE_DIR}/test/data/split/single/150overlap16bins13window1errors.gff.out
-                URL_HASH SHA256=8411628c483c0cd8e69611e03f4bd3ef944f4935552abf8c658af144b7bc88dc)
+                URL_HASH SHA256=37a6c5d2e8ac08cb7a472b3b9f21b10ddf2fbec0a1571fe9a55c6c1061291e9b)
 declare_datasource (FILE 150overlap16bins13window.ibf
                 URL ${CMAKE_SOURCE_DIR}/test/data/split/single/150overlap16bins13window.ibf
                 URL_HASH SHA256=bf2db42adc669ab73b074d74758ad56cf35d0c396031a0e73809b659fe8a76ce)
 declare_datasource (FILE 150overlap16bins15window1errors.gff.out
                 URL ${CMAKE_SOURCE_DIR}/test/data/split/single/150overlap16bins15window1errors.gff.out
-                URL_HASH SHA256=8411628c483c0cd8e69611e03f4bd3ef944f4935552abf8c658af144b7bc88dc)
+                URL_HASH SHA256=a5aa61f11a8e2543f7f1444d8f12a5822c2f49f13aba8727b54df64323a1ba28)
 declare_datasource (FILE 150overlap16bins15window.ibf
                 URL ${CMAKE_SOURCE_DIR}/test/data/split/single/150overlap16bins15window.ibf
                 URL_HASH SHA256=cb18705eaa1a94963969e7381efc3b5c099c241d7446a7292203c5d5b434b127)
@@ -30,13 +30,13 @@ declare_datasource (FILE 150overlap16bins.txt
                 URL_HASH SHA256=39501216962a5103aad09575248167cf5cfa63c96598ea8fcd7134421e1c8504)
 declare_datasource (FILE 150overlap4bins13window1errors.gff.out
                 URL ${CMAKE_SOURCE_DIR}/test/data/split/single/150overlap4bins13window1errors.gff.out
-                URL_HASH SHA256=397a2361e638b194db2ed726937ca1037b9ea5ca5f5f8938d97b5018e66cff53)
+                URL_HASH SHA256=55a82889d1f1310770f59de90e9b3e473538da33c973eff288ef6af26051bb70)
 declare_datasource (FILE 150overlap4bins13window.ibf
                 URL ${CMAKE_SOURCE_DIR}/test/data/split/single/150overlap4bins13window.ibf
                 URL_HASH SHA256=ce7b31acef135e024af9268b3416030d85e4c2828bc8c5dc3d1f18a34a03d373)
 declare_datasource (FILE 150overlap4bins15window1errors.gff.out
                 URL ${CMAKE_SOURCE_DIR}/test/data/split/single/150overlap4bins15window1errors.gff.out
-                URL_HASH SHA256=b83f53c3ac16421fd13abba5fd65ab9779cdf8339d721881c77a1439f2be28fd)
+                URL_HASH SHA256=435cd022f8faf13d4e41eacb8bf77fdd13baf33c6fccd83d207fa9f40a02bf99)
 declare_datasource (FILE 150overlap4bins15window.ibf
                 URL ${CMAKE_SOURCE_DIR}/test/data/split/single/150overlap4bins15window.ibf
                 URL_HASH SHA256=bc803cda05ef409a258420268d31e7ba3d8a5175b8292175cf40bdab10565ff5)

--- a/test/data/split/cli_test_output.sh
+++ b/test/data/split/cli_test_output.sh
@@ -19,7 +19,7 @@ do
         echo "Splitting the genome into $b segments that overlap by $o"
         ref_meta="multi/chromosome_"$o"overlap"$b"bins.txt"
         seg_meta="multi/"$o"overlap"$b"bins.txt"
-        valik split "$seg_input" --overlap "$o" --bins "$b" --reference-output "$ref_meta" --segment-output "$seg_meta"
+        valik split "$seg_input" --overlap "$o" --bins "$b" --ref-meta "$ref_meta" --seg-meta "$seg_meta"
     done
 done
 
@@ -53,17 +53,17 @@ do
     echo "Splitting the genome into $b segments that overlap by $seg_overlap"
     ref_meta="single/ref_"$seg_overlap"overlap"$b"bins.txt"
     seg_meta="single/"$seg_overlap"overlap"$b"bins.txt"
-    valik split "$ref_input" --overlap "$seg_overlap" --bins "$b" --reference-output "$ref_meta" --segment-output "$seg_meta"
+    valik split "$ref_input" --overlap "$seg_overlap" --bins "$b" --ref-meta "$ref_meta" --seg-meta "$seg_meta"
 
     for w in 13 15
     do
         echo "Creating IBF for w=$w and k=$k where segments overlap by $seg_overlap"
         index="single/"$seg_overlap"overlap"$b"bins"$w"window.ibf"
-        valik build "$ref_input" --kmer "$k" --window "$w" --size "$ibf_size" --output "$index" --from-segments --ref-meta "$ref_meta" --seg-path "$seg_meta"
+        valik build "$ref_input" --kmer "$k" --window "$w" --size "$ibf_size" --output "$index" --from-segments --ref-meta "$ref_meta" --seg-meta "$seg_meta"
 
         echo "Searching IBF with $errors errors"
         search_out="single/"$seg_overlap"overlap"$b"bins"$w"window"$errors"errors.gff"
-        valik search --index "$index" --query "$query" --output "$search_out" --error "$errors" --pattern "$pattern" --overlap "$pat_overlap" --tau "$tau" --p_max "$p_max" --seg-path "$seg_meta" --threads 1
+        valik search --index "$index" --query "$query" --output "$search_out" --error "$errors" --pattern "$pattern" --overlap "$pat_overlap" --tau "$tau" --p_max "$p_max" --ref-meta "$ref_meta" --seg-meta "$seg_meta" --threads 1
     rm "$search_out"
     done
 done

--- a/test/data/split/single/150overlap16bins13window1errors.gff.out
+++ b/test/data/split/single/150overlap16bins13window1errors.gff.out
@@ -1,10 +1,10 @@
-single_reference.fasta tmp/valik/my_dir/query_14_0.fasta --sequenceOfInterest 0 --segmentBegin 8974 --segmentEnd 9765 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_14_0.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_13_0.fasta --sequenceOfInterest 0 --segmentBegin 8333 --segmentEnd 9124 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_13_0.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_10_0.fasta --sequenceOfInterest 0 --segmentBegin 6410 --segmentEnd 7201 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_10_0.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_9_0.fasta --sequenceOfInterest 0 --segmentBegin 5769 --segmentEnd 6560 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_9_0.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_7_0.fasta --sequenceOfInterest 0 --segmentBegin 4487 --segmentEnd 5278 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_7_0.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_6_0.fasta --sequenceOfInterest 0 --segmentBegin 3846 --segmentEnd 4637 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_6_0.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_5_0.fasta --sequenceOfInterest 0 --segmentBegin 3205 --segmentEnd 3996 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_5_0.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_3_0.fasta --sequenceOfInterest 0 --segmentBegin 1923 --segmentEnd 2714 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_3_0.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_1_0.fasta --sequenceOfInterest 0 --segmentBegin 641 --segmentEnd 1432 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_1_0.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_0_0.fasta --sequenceOfInterest 0 --segmentBegin 0 --segmentEnd 791 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_0_0.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_14_0.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 8974 --segmentEnd 9765 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_14_0.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_13_0.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 8333 --segmentEnd 9124 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_13_0.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_10_0.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 6410 --segmentEnd 7201 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_10_0.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_9_0.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 5769 --segmentEnd 6560 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_9_0.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_7_0.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 4487 --segmentEnd 5278 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_7_0.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_6_0.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 3846 --segmentEnd 4637 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_6_0.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_5_0.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 3205 --segmentEnd 3996 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_5_0.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_3_0.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 1923 --segmentEnd 2714 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_3_0.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_1_0.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 641 --segmentEnd 1432 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_1_0.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_0_0.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 0 --segmentEnd 791 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_0_0.fasta.gff

--- a/test/data/split/single/150overlap16bins15window1errors.gff.out
+++ b/test/data/split/single/150overlap16bins15window1errors.gff.out
@@ -1,10 +1,10 @@
-single_reference.fasta tmp/valik/my_dir/query_14_0.fasta --sequenceOfInterest 0 --segmentBegin 8974 --segmentEnd 9765 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_14_0.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_13_0.fasta --sequenceOfInterest 0 --segmentBegin 8333 --segmentEnd 9124 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_13_0.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_10_0.fasta --sequenceOfInterest 0 --segmentBegin 6410 --segmentEnd 7201 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_10_0.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_9_0.fasta --sequenceOfInterest 0 --segmentBegin 5769 --segmentEnd 6560 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_9_0.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_7_0.fasta --sequenceOfInterest 0 --segmentBegin 4487 --segmentEnd 5278 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_7_0.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_6_0.fasta --sequenceOfInterest 0 --segmentBegin 3846 --segmentEnd 4637 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_6_0.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_5_0.fasta --sequenceOfInterest 0 --segmentBegin 3205 --segmentEnd 3996 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_5_0.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_3_0.fasta --sequenceOfInterest 0 --segmentBegin 1923 --segmentEnd 2714 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_3_0.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_1_0.fasta --sequenceOfInterest 0 --segmentBegin 641 --segmentEnd 1432 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_1_0.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_0_0.fasta --sequenceOfInterest 0 --segmentBegin 0 --segmentEnd 791 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_0_0.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_1_0.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 641 --segmentEnd 1432 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_1_0.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_14_0.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 8974 --segmentEnd 9765 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_14_0.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_13_0.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 8333 --segmentEnd 9124 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_13_0.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_10_0.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 6410 --segmentEnd 7201 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_10_0.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_9_0.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 5769 --segmentEnd 6560 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_9_0.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_7_0.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 4487 --segmentEnd 5278 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_7_0.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_6_0.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 3846 --segmentEnd 4637 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_6_0.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_5_0.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 3205 --segmentEnd 3996 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_5_0.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_3_0.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 1923 --segmentEnd 2714 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_3_0.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_0_0.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 0 --segmentEnd 791 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_0_0.fasta.gff

--- a/test/data/split/single/150overlap4bins13window1errors.gff.out
+++ b/test/data/split/single/150overlap4bins13window1errors.gff.out
@@ -1,10 +1,10 @@
-single_reference.fasta tmp/valik/my_dir/query_2_0.fasta --sequenceOfInterest 0 --segmentBegin 5122 --segmentEnd 7833 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_2_0.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_1_0.fasta --sequenceOfInterest 0 --segmentBegin 2561 --segmentEnd 5272 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_1_0.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_2_1.fasta --sequenceOfInterest 0 --segmentBegin 5122 --segmentEnd 7833 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_2_1.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_3_0.fasta --sequenceOfInterest 0 --segmentBegin 7683 --segmentEnd 10240 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_3_0.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_2_2.fasta --sequenceOfInterest 0 --segmentBegin 5122 --segmentEnd 7833 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_2_2.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_0_0.fasta --sequenceOfInterest 0 --segmentBegin 0 --segmentEnd 2711 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_0_0.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_0_1.fasta --sequenceOfInterest 0 --segmentBegin 0 --segmentEnd 2711 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_0_1.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_3_1.fasta --sequenceOfInterest 0 --segmentBegin 7683 --segmentEnd 10240 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_3_1.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_0_2.fasta --sequenceOfInterest 0 --segmentBegin 0 --segmentEnd 2711 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_0_2.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_1_1.fasta --sequenceOfInterest 0 --segmentBegin 2561 --segmentEnd 5272 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_1_1.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_2_0.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 5122 --segmentEnd 7833 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_2_0.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_3_0.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 7683 --segmentEnd 10240 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_3_0.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_2_1.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 5122 --segmentEnd 7833 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_2_1.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_0_0.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 0 --segmentEnd 2711 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_0_0.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_1_0.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 2561 --segmentEnd 5272 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_1_0.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_2_2.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 5122 --segmentEnd 7833 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_2_2.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_0_1.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 0 --segmentEnd 2711 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_0_1.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_3_1.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 7683 --segmentEnd 10240 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_3_1.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_0_2.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 0 --segmentEnd 2711 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_0_2.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_1_1.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 2561 --segmentEnd 5272 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_1_1.fasta.gff

--- a/test/data/split/single/150overlap4bins15window1errors.gff.out
+++ b/test/data/split/single/150overlap4bins15window1errors.gff.out
@@ -1,4 +1,4 @@
-single_reference.fasta tmp/valik/my_dir/query_0_0.fasta --sequenceOfInterest 0 --segmentBegin 0 --segmentEnd 2711 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_0_0.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_3_0.fasta --sequenceOfInterest 0 --segmentBegin 7683 --segmentEnd 10240 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_3_0.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_2_0.fasta --sequenceOfInterest 0 --segmentBegin 5122 --segmentEnd 7833 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_2_0.fasta.gff
-single_reference.fasta tmp/valik/my_dir/query_1_0.fasta --sequenceOfInterest 0 --segmentBegin 2561 --segmentEnd 5272 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_1_0.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_0_0.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 0 --segmentEnd 2711 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_0_0.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_3_0.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 7683 --segmentEnd 10240 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_3_0.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_2_0.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 5122 --segmentEnd 7833 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_2_0.fasta.gff
+single_reference.fasta tmp/valik/my_dir/query_1_0.fasta --referenceLength 10240 --sequenceOfInterest 0 --segmentBegin 2561 --segmentEnd 5272 -e 0.020000 -l 50 -o tmp/valik/my_dir/query_1_0.fasta.gff


### PR DESCRIPTION
This breaks existing workflows. 

Before: different parameter names for the same metadata file 

After: valik {split, search, build, consolidate} use the same parameter names `--ref-meta ref.txt --seg-meta seg.txt`

The new signature to call stellar3 with reference length input comes from https://github.com/seqan/stellar3/pull/4