### PR TITLE
Refactor split parameter tuning

### DIFF
--- a/include/utilities/threshold/basics.hpp
+++ b/include/utilities/threshold/basics.hpp
@@ -59,7 +59,7 @@ struct param_space
     constexpr static uint8_t max_errors{15};    
     uint16_t max_thresh{20};
     constexpr static size_t max_len{150};
-    constexpr static std::pair<uint8_t, uint8_t> kmer_range{9, 35};
+    constexpr static std::pair<uint8_t, uint8_t> kmer_range{9, 23};
 
     param_space() noexcept = default;
     param_space(param_space const &) noexcept = default;

--- a/include/utilities/threshold/filtering_request.hpp
+++ b/include/utilities/threshold/filtering_request.hpp
@@ -23,16 +23,7 @@ struct filtering_request
     const metadata & query_meta;
 
     filtering_request(search_pattern const & pat, metadata const & ref, metadata const & query) : 
-                      pattern(pat), ref_meta(ref), query_meta(query)
-    {
-        auto space = param_space();
-        if (pat.e > space.max_errors)
-            throw std::runtime_error{"error_count=" + std::to_string(pat.e) + " out of range [0, " + 
-                                     std::to_string(space.max_errors) + "]"};
-        if (pat.l > space.max_len)
-            throw std::runtime_error{"min_len=" + std::to_string(pat.l) + " out of range [0, " + 
-                                     std::to_string(space.max_len) + "]"};
-    }
+                      pattern(pat), ref_meta(ref), query_meta(query) { }
 
     /**
      * @brief An approximation of the probability of a query segment having a spurious match in a reference bin. 

--- a/include/valik/shared.hpp
+++ b/include/valik/shared.hpp
@@ -68,7 +68,7 @@ struct split_arguments
     float error_rate{0.05};
     uint8_t errors{0};
     float fpr{0.05};
-    uint8_t kmer_size{20};
+    uint8_t kmer_size{std::numeric_limits<uint8_t>::max()};
     bool metagenome{false};
     std::filesystem::path ref_meta_path{};
     bool write_out{false};

--- a/src/argument_parsing/split.cpp
+++ b/src/argument_parsing/split.cpp
@@ -55,7 +55,7 @@ void init_split_parser(sharg::parser & parser, split_arguments & arguments)
     parser.add_flag(arguments.write_out,
                       sharg::config{.short_id = '\0',
                       .long_id = "write-out",
-                      .description = "Write an output FASTA file for each reference segment or write all query segments into a single output FASTA file..",
+                      .description = "Write an output FASTA file for each reference segment or write all query segments into a single output FASTA file.",
                       .advanced = true});
     parser.add_flag(arguments.only_split,
                       sharg::config{.short_id = '\0',

--- a/src/argument_parsing/split.cpp
+++ b/src/argument_parsing/split.cpp
@@ -118,12 +118,6 @@ void run_split(sharg::parser & parser)
         arguments.meta_out.replace_extension("bin");
     }
 
-    if (parser.is_option_set("kmer") && !arguments.only_split)
-    {
-        std::cerr << "WARNING: kmer size will be adjusted for database size. "
-                  << "Set --without-parameter-tuning to force manual input.\n";
-    }
-
     if (parser.is_option_set("seg-count") && !arguments.only_split)
     {
         std::cerr << "WARNING: seg count will be adjusted to the next multiple of 64. "

--- a/src/threshold/find.cpp
+++ b/src/threshold/find.cpp
@@ -13,8 +13,16 @@ param_set get_best_params(search_pattern const & pattern,
 {
     param_space space = fn_attr.space;
 
-    if (kmer_lemma_threshold(pattern.l, space.max_k(), pattern.e) > space.max_thresh)
-        return param_set(space.max_k(), kmer_lemma_threshold(pattern.l, space.max_k(), pattern.e));
+    if (pattern.l > space.max_len)
+    {
+        for (uint8_t k = space.max_k(); k >= space.min_k(); k--)
+        {
+            if (kmer_lemma_threshold(pattern.l, k, pattern.e) > THRESH_LOWER)
+                return param_set(k, kmer_lemma_threshold(pattern.l, k, pattern.e));
+        }
+
+        throw std::runtime_error{"Unable to deduce threshold for min_len=" + std::to_string(pattern.l) + " and errors=" + std::to_string(pattern.e)};
+    }
 
     param_set best_params(space.min_k(), 1, space);
     auto best_score = score(fn_attr.get_kmer_loss(space.min_k()), pattern, best_params, ref_meta, PATTERNS_PER_SEGMENT);

--- a/src/valik_split.cpp
+++ b/src/valik_split.cpp
@@ -48,8 +48,11 @@ void valik_split(split_arguments & arguments)
             std::cout << "max error rate " << arguments.error_rate << '\n';
         }
         
-        auto best_params = get_best_params(pattern, meta, fn_attr, arguments.verbose);
-        arguments.kmer_size = best_params.k;
+        if (arguments.kmer_size == std::numeric_limits<uint8_t>::max())
+        {
+            auto best_params = get_best_params(pattern, meta, fn_attr, arguments.verbose);
+            arguments.kmer_size = best_params.k;
+        }
         const kmer_loss & attr = fn_attr.get_kmer_loss(arguments.kmer_size);
 
         search_kmer_profile search_profile = find_thresholds_for_kmer_size(meta, attr, arguments.errors);

--- a/test/api/utilities/threshold/kmer_loss_test.cpp
+++ b/test/api/utilities/threshold/kmer_loss_test.cpp
@@ -184,13 +184,13 @@ void try_fnr(uint8_t e, size_t l, uint8_t k, uint16_t t, double expected_fnr)
 
 TEST(false_negative, try_kmer_lemma_thershold)
 {
-    try_fnr(0u, (size_t) 50, 16u, 35u, 0.0);
+    try_fnr(0u, (size_t) 50, 16u, 23u, 0.0);
     try_fnr(1u, (size_t) 50, 16u, 19u, 0.0);
     try_fnr(2u, (size_t) 50, 16u, 3u, 0.0);
 
-    try_fnr(0u, (size_t) 1000, 35u, 966u, 0.0);
-    try_fnr(1u, (size_t) 1000, 35u, 931u, 0.0);
-    try_fnr(2u, (size_t) 1000, 35u, 896u, 0.0);
+    try_fnr(0u, (size_t) 1000, 23u, 978u, 0.0);
+    try_fnr(1u, (size_t) 1000, 23u, 955u, 0.0);
+    try_fnr(2u, (size_t) 1000, 23u, 932u, 0.0);
 }
 
 TEST(false_negative, try_threshold_above_kmer_lemma)

--- a/test/api/utilities/threshold/param_set_test.cpp
+++ b/test/api/utilities/threshold/param_set_test.cpp
@@ -14,7 +14,7 @@ TEST(error_handling, kmer_size)
         }
         catch( const std::runtime_error& e )
         {
-            EXPECT_STREQ( ("k=" + std::to_string(kmer_size) + " out of range [9, 35]").c_str(), e.what() );
+            EXPECT_STREQ( ("k=" + std::to_string(kmer_size) + " out of range [9, 23]").c_str(), e.what() );
             throw;
         }
     }, std::runtime_error );
@@ -32,7 +32,7 @@ TEST(error_handling, kmer_size)
         }
         catch( const std::runtime_error& e )
         {
-            EXPECT_STREQ( ("k=" + std::to_string(kmer_size) + " out of range [9, 35]").c_str(), e.what() );
+            EXPECT_STREQ( ("k=" + std::to_string(kmer_size) + " out of range [9, 23]").c_str(), e.what() );
             throw;
         }
     }, std::runtime_error );


### PR DESCRIPTION
The automatic parameter deduction for k-mer size and threshold relies on a precalculated dynamic programming table. The DP table grows the fastest with the maximum threshold. 

New in this PR: 
- if the chosen pattern size is out of the precalculated range, use the k-mer lemma threshold
- allow setting k-mer size manually and deducing other parameters