### PR TITLE
[FEAT] Calculate threshold for gapped k-mers

### DIFF
--- a/include/utilities/threshold/basics.hpp
+++ b/include/utilities/threshold/basics.hpp
@@ -10,9 +10,6 @@
 #include <filesystem>
 #include <map>
 
-#include <seqan3/search/kmer_index/shape.hpp>
-#include <seqan3/core/debug_stream.hpp>
-
 #include <cereal/archives/binary.hpp> 
 #include <cereal/types/tuple.hpp>
 
@@ -38,58 +35,6 @@ double expected_kmer_occurrences(var_t const & bin_size,
 }
 
 /**
- * @brief K-mer lemma threshold.
-*/
-inline size_t kmer_lemma_threshold(size_t const l, uint8_t const k, uint8_t const e)
-{
-    if (l < k)
-        return 0;
-    if ((l - k + 1) <= (size_t) e*k)
-        return 0;
-    
-    return l - k + 1 - e * k;
-}
-
-/**
- * @brief Gapped k-mer threshold.
-*/
-inline size_t gapped_kmer_threshold(size_t const l, seqan3::shape const shape, uint8_t const e)
-{
-    uint8_t k = shape.size();
-    uint8_t longest_ungapped{0};
-
-    if (shape.count() == shape.size())
-        longest_ungapped = shape.size();
-    else
-    {
-        uint8_t curr_ungapped{0};
-        for (auto c : shape.to_string())
-        {
-            if (c == '1')
-                curr_ungapped++;
-            else
-            {
-                if (curr_ungapped > longest_ungapped)
-                    longest_ungapped = curr_ungapped;
-                curr_ungapped = 0;
-            }
-        }
-        if (curr_ungapped > longest_ungapped)
-            longest_ungapped = curr_ungapped;
-    }
-
-    if (longest_ungapped == 0)
-        throw std::runtime_error{"No ungapped section in " + shape.to_string()};
-        
-    if (l < k)
-        return 0;
-    if ((l - k + 1) <= (size_t) e*longest_ungapped)
-        return 0;
-    
-    return l - k + 1 - e * longest_ungapped;
-}
-
-/**
  * @brief Definition of the search space for the parameter tuning algorithm.
  * 
  * @param max_errors Maximum number of errors.
@@ -102,7 +47,7 @@ struct param_space
     constexpr static uint8_t max_errors{15};    
     uint16_t max_thresh{20};
     constexpr static size_t max_len{150};
-    constexpr static std::pair<uint8_t, uint8_t> kmer_range{9, 23};
+    constexpr static std::pair<uint8_t, uint8_t> kmer_range{7, 23};
 
     param_space() noexcept = default;
     param_space(param_space const &) noexcept = default;

--- a/include/utilities/threshold/fn_confs.hpp
+++ b/include/utilities/threshold/fn_confs.hpp
@@ -19,7 +19,7 @@ struct fn_confs
      */
     std::filesystem::path fn_filename()
     {
-        std::string outfile = "gapped_fn_err_conf_e" + std::to_string(space.max_errors) + "_t" + std::to_string(space.max_thresh) + 
+        std::string outfile = "fn_err_conf_e" + std::to_string(space.max_errors) + "_t" + std::to_string(space.max_thresh) + 
                                                 "_l" + std::to_string(space.max_len) + "_k" + 
                                                 std::to_string(space.min_k()) + "_" + 
                                                 std::to_string(space.max_k()) + ".bin";
@@ -89,6 +89,20 @@ struct fn_confs
                 precalc_fn_confs();
         }
 
+        kmer_loss & get_kmer_loss(utilities::kmer const & valik_kmer)
+        {
+            uint8_t k = std::max(space.min_k(), valik_kmer.effective_size());
+            if (k < space.min_k() || k > space.max_k())
+            {
+                throw std::runtime_error("k-mer length " + std::to_string(k) + " is out of range [" + 
+                      std::to_string(space.min_k()) + ", " + std::to_string(space.max_k()) + "]");
+            }
+
+            //!TODO: make const
+            attr_vec[k - space.min_k()].kmer = valik_kmer;
+            return attr_vec[k - space.min_k()];
+        }
+
         const kmer_loss & get_kmer_loss(uint8_t const k) const
         {
             if (k < space.min_k() || k > space.max_k())
@@ -96,22 +110,7 @@ struct fn_confs
                 throw std::runtime_error("k-mer length " + std::to_string(k) + " is out of range [" + 
                       std::to_string(space.min_k()) + ", " + std::to_string(space.max_k()) + "]");
             }
-            
-            return attr_vec[k - space.min_k()];
-        }
 
-        const kmer_loss & get_kmer_loss(seqan3::shape const shape)
-        {
-            uint8_t k = shape.count();
-            if (k < space.min_k() || k > space.max_k())
-            {
-                throw std::runtime_error("k-mer length " + std::to_string(k) + " is out of range [" + 
-                      std::to_string(space.min_k()) + ", " + std::to_string(space.max_k()) + "]");
-            }
-
-            //!TODO: increase precalculated attribute FN values to account for gapped shapes
-            // currently treating gapped k-mers as same weight ungapped k-mers
-            attr_vec[k - space.min_k()].shape = shape;
             return attr_vec[k - space.min_k()];
         }
 };

--- a/include/utilities/threshold/fn_confs.hpp
+++ b/include/utilities/threshold/fn_confs.hpp
@@ -19,7 +19,7 @@ struct fn_confs
      */
     std::filesystem::path fn_filename()
     {
-        std::string outfile = "fn_err_conf_e" + std::to_string(space.max_errors) + "_t" + std::to_string(space.max_thresh) + 
+        std::string outfile = "gapped_fn_err_conf_e" + std::to_string(space.max_errors) + "_t" + std::to_string(space.max_thresh) + 
                                                 "_l" + std::to_string(space.max_len) + "_k" + 
                                                 std::to_string(space.min_k()) + "_" + 
                                                 std::to_string(space.max_k()) + ".bin";
@@ -102,15 +102,15 @@ struct fn_confs
 
         const kmer_loss & get_kmer_loss(seqan3::shape const shape)
         {
-            uint8_t k = shape.size();
+            uint8_t k = shape.count();
             if (k < space.min_k() || k > space.max_k())
             {
                 throw std::runtime_error("k-mer length " + std::to_string(k) + " is out of range [" + 
                       std::to_string(space.min_k()) + ", " + std::to_string(space.max_k()) + "]");
             }
 
-            //!TODO: adjust precalculated attribute vectors to account for gapped shapes
-            // currently hack to copy the ungapped attribute without adjusting threshold 
+            //!TODO: increase precalculated attribute FN values to account for gapped shapes
+            // currently treating gapped k-mers as same weight ungapped k-mers
             attr_vec[k - space.min_k()].shape = shape;
             return attr_vec[k - space.min_k()];
         }

--- a/include/utilities/threshold/kmer.hpp
+++ b/include/utilities/threshold/kmer.hpp
@@ -66,7 +66,6 @@ struct kmer
             return shape.count();
     }
 
-    //!TODO: cout triplets
     uint8_t ungapped_triplet_length() const
     {
         if (is_gapped())

--- a/include/utilities/threshold/kmer.hpp
+++ b/include/utilities/threshold/kmer.hpp
@@ -8,6 +8,7 @@
 #include <seqan3/core/debug_stream.hpp>
 
 #include <cereal/archives/binary.hpp> 
+#include <cereal/types/string.hpp>
 
 namespace utilities
 {

--- a/include/utilities/threshold/kmer.hpp
+++ b/include/utilities/threshold/kmer.hpp
@@ -1,0 +1,184 @@
+#pragma once
+
+#include <cstdint>
+#include <charconv>
+#include <string>
+
+#include <seqan3/search/kmer_index/shape.hpp>
+#include <seqan3/core/debug_stream.hpp>
+
+#include <cereal/archives/binary.hpp> 
+
+namespace utilities
+{
+
+/**
+ * @brief A sequence submer.
+ * 
+ * @param k K-mer size.
+ * @param kmer_weight Less than k-mer size for gapped k-mers.
+ * @param t Threshold for minimum number of shared k-mers.
+*/
+struct kmer
+{
+    seqan3::shape shape;
+
+    kmer() noexcept = default;
+    kmer(kmer const &) noexcept = default;
+    kmer & operator=(kmer const &) noexcept = default;
+    kmer & operator=(kmer &&) noexcept = default;
+    ~kmer() noexcept = default;
+
+    kmer(seqan3::shape const kmer_shape) : shape(kmer_shape) {}
+
+    kmer(uint8_t const kmer_size) : 
+        kmer(seqan3::shape{seqan3::ungapped{kmer_size}}) {}
+
+    bool is_gapped() const
+    {
+        return shape.count() < shape.size();
+    }
+
+    uint8_t longest_ungapped() const
+    {
+        if (is_gapped())
+        {
+            uint8_t longest_ungapped{0};
+            uint8_t curr_ungapped{0};
+            for (auto c : shape.to_string())
+            {
+                if (c == '1')
+                    curr_ungapped++;
+                else
+                {
+                    if (curr_ungapped > longest_ungapped)
+                        longest_ungapped = curr_ungapped;
+                    curr_ungapped = 0;
+                }
+            }
+            if (curr_ungapped > longest_ungapped)
+                longest_ungapped = curr_ungapped;
+            
+            return longest_ungapped;
+        }
+        else
+            return shape.count();
+    }
+
+    //!TODO: cout triplets
+    uint8_t ungapped_triplet_length() const
+    {
+        if (is_gapped())
+        {
+            uint8_t ungapped_triplet_length{0};
+            std::vector<size_t> triplet_pos{};
+
+            std::string shape_str = to_string();
+            std::string substr{"111"};
+            size_t pos = shape_str.find(substr, 0);
+            while( pos != std::string::npos )
+            {
+                triplet_pos.push_back(pos);
+                pos = shape_str.find(substr, pos+1);
+            }
+            
+            if (!triplet_pos.empty())
+            {
+                size_t prev_pos = *triplet_pos.begin();
+                for (auto it = triplet_pos.begin(); it < triplet_pos.end(); ++it)
+                {
+                    if (*it == (prev_pos + 1))
+                        ungapped_triplet_length++;
+                    else
+                        ungapped_triplet_length += 3;
+                    prev_pos = *it;
+                }
+            }
+
+            return ungapped_triplet_length;
+        }
+        else
+            return size();
+    }
+
+    uint8_t weight() const
+    {
+        return shape.count();
+    }
+
+    uint8_t size() const
+    {
+        return shape.size();
+    }
+
+    uint8_t effective_size() const
+    {
+        if (is_gapped())
+        {
+            // 28 18 20 16
+            // double ungapped_frac = weight() / (double) size();
+            // return std::round(longest_ungapped() * (1 + ungapped_frac));
+            // 
+            // 28 17 18 13
+            return ungapped_triplet_length();
+        }
+        else
+            return size();
+    }
+
+    std::string to_string() const
+    {
+        return shape.to_string();
+    }
+
+    bool operator==(kmer const & other) const
+    {
+        return (to_string() == other.to_string());
+    }
+
+    /**
+     * @brief K-mer lemma threshold.
+    */
+    inline size_t lemma_threshold(size_t const l, uint8_t const e) const
+    {
+        uint8_t k = size();
+        if (l < k)
+            return 0;
+        if ((l - k + 1) <= (size_t) e*k)
+            return 0;
+
+        return l - k + 1 - e * k;
+    }
+
+    /**
+     * @brief Gapped k-mer threshold.
+    */
+    inline size_t gapped_threshold(size_t const l, uint8_t const e) const
+    {
+        uint8_t k = size();
+        if (l < k)
+            return 0;
+        if ((l - k + 1) <= (size_t) e*effective_size())
+            return 0;
+
+        return l - k + 1 - e * effective_size();
+    }
+
+    template<class Archive>
+    void save(Archive & archive) const
+    {
+        archive(shape.to_string()); 
+    }
+
+    template<class Archive>
+    void load(Archive & archive)
+    {
+        std::string shape_str;
+        archive(shape_str);
+        uint64_t bin_shape{};
+        std::from_chars(shape_str.data(), shape_str.data() + shape_str.size(), bin_shape, 2);
+        shape = seqan3::shape(seqan3::bin_literal{bin_shape});
+    }
+};
+
+}   // namespace utilities

--- a/include/utilities/threshold/kmer_loss.hpp
+++ b/include/utilities/threshold/kmer_loss.hpp
@@ -15,6 +15,7 @@ namespace valik
  * @brief For a kmer size k consider how the FNR changes for various values of the parameters t, e and l. 
  *   
  * @param k Chosen k-mer size.
+ * @param kmer_weight Less than k-mer size for gapped k-mers.
  * @param fn_conf_counts Number of configurations of e errors that do not retain at least t shared kmers after mutation.
 */
 struct kmer_loss
@@ -24,7 +25,7 @@ struct kmer_loss
     using mat_t = std::vector<table_t>;
     
     uint8_t k;
-    //!TODO: adjust the error configuration calculation for gapped k-mers 
+    uint8_t kmer_weight;
     seqan3::shape shape;
     mat_t fn_conf_counts;  // false negative configuration counts
 
@@ -50,19 +51,19 @@ struct kmer_loss
                 for(size_t l = 0; l <= space.max_len; l++)
                 {       
                     int shared_base_count = l - e;
-                    if ((int) (k + t) - 1 > shared_base_count) // all error distributions destroy enough k-mers
+                    if ((int) (kmer_weight + t) - 1 > shared_base_count) // all error distributions destroy enough k-mers
                         row.push_back(combinations(e, l));
                     else if (e == 0)    // this has to be after the first condition; not everything in first row should be 0
                         row.push_back(0);
                     else
                     {                        
                         row.push_back(row.back() + table.back()[l - 1]);
-                        row.back() -= table.back()[l - k - 1];
+                        row.back() -= table.back()[l - kmer_weight - 1];
 
                         for (uint8_t i = 1; i < t; i++)
                         {
-                            row.back() -= matrix[matrix.size() - i][e - 1][l - k - i - 1];
-                            row.back() += matrix[matrix.size() - i][e - 1][l - k - i];
+                            row.back() -= matrix[matrix.size() - i][e - 1][l - kmer_weight - i - 1];
+                            row.back() += matrix[matrix.size() - i][e - 1][l - kmer_weight - i];
                         }
                     }
                 }
@@ -75,20 +76,21 @@ struct kmer_loss
 
     kmer_loss(uint8_t const kmer_size, param_space const & space) : 
                     k(kmer_size),
-                    shape(seqan3::shape(seqan3::ungapped(kmer_size))),
+                    kmer_weight(kmer_size),
                     fn_conf_counts(count_err_conf_below_thresh(space)) { }
 
     kmer_loss(seqan3::shape const kmer_shape, param_space const & space) : 
                     k(kmer_shape.size()), 
-                    shape(kmer_shape),
+                    kmer_weight(kmer_shape.count()),
                     fn_conf_counts(count_err_conf_below_thresh(space)) { }
 
     /**
      * @brief False negative rate for a parameter set.
     */
     double fnr_for_param_set(search_pattern const & pattern, param_set const & params) const
-    {        
-        if (kmer_lemma_threshold(pattern.l, params.k, pattern.e) >= params.t)
+    {
+        //!TODO: differentiate between gapped and ungapped shapes
+        if (kmer_lemma_threshold(pattern.l, params.kmer_weight, pattern.e) >= params.t)
             return 0.0;
         if (params.t > fn_conf_counts.size())
             throw std::runtime_error("Calculated configuration count table for threshold=[1, " + std::to_string(fn_conf_counts.size()) + "]. " 
@@ -105,7 +107,7 @@ struct kmer_loss
     template<class Archive>
     void serialize(Archive & archive)
     {
-      archive(k, fn_conf_counts);
+      archive(k, kmer_weight, fn_conf_counts);
     }
 };
 

--- a/include/utilities/threshold/param_set.hpp
+++ b/include/utilities/threshold/param_set.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
 #include <cstdint>
+#include <charconv>
 
+#include <utilities/threshold/kmer.hpp>
 #include <utilities/threshold/basics.hpp>
-
-#include <seqan3/search/kmer_index/shape.hpp>
 
 #include <cereal/archives/binary.hpp> 
 
@@ -20,8 +20,7 @@ namespace valik
 */
 struct param_set
 {
-    uint8_t k;
-    uint8_t kmer_weight;
+    utilities::kmer kmer;
     uint16_t t;
 
     param_set() noexcept = default;
@@ -30,15 +29,14 @@ struct param_set
     param_set & operator=(param_set &&) noexcept = default;
     ~param_set() noexcept = default;
 
-    param_set(seqan3::shape const shape, uint16_t const thresh, param_space const & space) : k(shape.size()), kmer_weight(shape.count()), t(thresh)
+    param_set(utilities::kmer const valik_kmer, uint16_t const thresh, param_space const & space) : kmer(valik_kmer), t(thresh)
     {
-        if ((kmer_weight < std::get<0>(space.kmer_range)) | (kmer_weight > std::get<1>(space.kmer_range)))
+        if ((kmer.weight() < std::get<0>(space.kmer_range)) | (kmer.weight() > std::get<1>(space.kmer_range)))
         {
-            throw std::runtime_error{"k=" + std::to_string(kmer_weight) + " out of range [" + 
+            throw std::runtime_error{"k=" + std::to_string(kmer.weight()) + " out of range [" + 
                                                 std::to_string(std::get<0>(space.kmer_range)) + ", " + 
                                                 std::to_string(std::get<1>(space.kmer_range)) + "]"}; 
-        }
-    
+        }    
         if (t > space.max_thresh)
         {
             throw std::runtime_error{"t=" + std::to_string(t) + " out of range [0, " + std::to_string(space.max_thresh) + "]"};
@@ -48,15 +46,28 @@ struct param_set
     param_set(uint8_t const kmer_size, uint16_t const thresh, param_space const & space) : 
         param_set(seqan3::shape{seqan3::ungapped{kmer_size}}, thresh, space) { }
 
-    param_set(seqan3::shape const shape, uint16_t const thresh) : k(shape.size()), kmer_weight(shape.count()), t(thresh) {}
+    param_set(seqan3::shape const kmer_shape, uint16_t const thresh) : kmer(kmer_shape), t(thresh) {}
 
     param_set(uint8_t const kmer_size, uint16_t const thresh) : 
         param_set(seqan3::shape{seqan3::ungapped{kmer_size}}, thresh) {}
 
-    template <class Archive>
-    void serialize(Archive & archive)
+    param_set(utilities::kmer const & k, uint16_t const thresh) : kmer{k}, t{thresh} {}
+
+
+    template<class Archive>
+    void save(Archive & archive) const
     {
-        archive(k, kmer_weight, t);
+        archive(kmer.to_string(), t); 
+    }
+
+    template<class Archive>
+    void load(Archive & archive)
+    {
+        std::string shape_str;
+        archive(shape_str, t);
+        uint64_t bin_shape{};
+        std::from_chars(shape_str.data(), shape_str.data() + shape_str.size(), bin_shape, 2);
+        kmer = utilities::kmer{seqan3::shape(seqan3::bin_literal{bin_shape})};
     }
 };
 

--- a/include/utilities/threshold/param_set.hpp
+++ b/include/utilities/threshold/param_set.hpp
@@ -4,6 +4,8 @@
 
 #include <utilities/threshold/basics.hpp>
 
+#include <seqan3/search/kmer_index/shape.hpp>
+
 #include <cereal/archives/binary.hpp> 
 
 namespace valik
@@ -13,11 +15,13 @@ namespace valik
  * @brief A point in the parameter tuning search space.
  * 
  * @param k K-mer size.
+ * @param kmer_weight Less than k-mer size for gapped k-mers.
  * @param t Threshold for minimum number of shared k-mers.
 */
 struct param_set
 {
     uint8_t k;
+    uint8_t kmer_weight;
     uint16_t t;
 
     param_set() noexcept = default;
@@ -26,27 +30,33 @@ struct param_set
     param_set & operator=(param_set &&) noexcept = default;
     ~param_set() noexcept = default;
 
-    param_set(uint8_t const kmer_size, uint16_t const thresh, param_space const & space) : k(kmer_size), t(thresh)
+    param_set(seqan3::shape const shape, uint16_t const thresh, param_space const & space) : k(shape.size()), kmer_weight(shape.count()), t(thresh)
     {
-        if ((kmer_size < std::get<0>(space.kmer_range)) | (kmer_size > std::get<1>(space.kmer_range)))
+        if ((kmer_weight < std::get<0>(space.kmer_range)) | (kmer_weight > std::get<1>(space.kmer_range)))
         {
-            throw std::runtime_error{"k=" + std::to_string(kmer_size) + " out of range [" + 
-                                                   std::to_string(std::get<0>(space.kmer_range)) + ", " + 
-                                                   std::to_string(std::get<1>(space.kmer_range)) + "]"}; 
+            throw std::runtime_error{"k=" + std::to_string(kmer_weight) + " out of range [" + 
+                                                std::to_string(std::get<0>(space.kmer_range)) + ", " + 
+                                                std::to_string(std::get<1>(space.kmer_range)) + "]"}; 
         }
-
-        if (thresh > space.max_thresh)
+    
+        if (t > space.max_thresh)
         {
-            throw std::runtime_error{"t=" + std::to_string(thresh) + " out of range [0, " + std::to_string(space.max_thresh) + "]"};
-        }
+            throw std::runtime_error{"t=" + std::to_string(t) + " out of range [0, " + std::to_string(space.max_thresh) + "]"};
+        } 
     }
 
-    param_set(uint8_t const kmer_size, uint16_t const thresh) : k(kmer_size), t(thresh) {}
+    param_set(uint8_t const kmer_size, uint16_t const thresh, param_space const & space) : 
+        param_set(seqan3::shape{seqan3::ungapped{kmer_size}}, thresh, space) { }
+
+    param_set(seqan3::shape const shape, uint16_t const thresh) : k(shape.size()), kmer_weight(shape.count()), t(thresh) {}
+
+    param_set(uint8_t const kmer_size, uint16_t const thresh) : 
+        param_set(seqan3::shape{seqan3::ungapped{kmer_size}}, thresh) {}
 
     template <class Archive>
     void serialize(Archive & archive)
     {
-        archive(k, t);
+        archive(k, kmer_weight, t);
     }
 };
 

--- a/include/valik/search/search_local.hpp
+++ b/include/valik/search/search_local.hpp
@@ -122,7 +122,7 @@ bool search_local(search_arguments & arguments, search_time_statistics & time_st
         {
             search_pattern pattern(arguments.errors, arguments.pattern_size);
             param_space space;
-            param_set params(arguments.shape_size, arguments.threshold);
+            param_set params(arguments.shape, arguments.threshold);
             filtering_request request(pattern, ref_meta, query_meta.value());
             if ((request.fpr(params) > 0.2) && (arguments.search_type != search_kind::STELLAR))
                 std::cerr << "WARNING: Prefiltering will be inefficient for a high error rate.\n";

--- a/include/valik/split/metadata.hpp
+++ b/include/valik/split/metadata.hpp
@@ -610,7 +610,7 @@ struct metadata
         double pattern_spurious_match_prob(param_set const & params, double const information_content = 0.35) const
         {
             double fpr{1};
-            double p = ibf_fpr + kmer_spurious_match_prob(params.k);
+            double p = ibf_fpr + kmer_spurious_match_prob(params.kmer.weight());
             const double precision{1e-9};
             /*
             For parameters 
@@ -634,7 +634,7 @@ struct metadata
             the probability of 1 k-mer out of n matching is P(1 k-mer matches) = (n take 1) * p^1 * (1 - p)^(n - 1).
             */
 
-        size_t kmers_per_pattern = std::min((size_t) params.t, pattern_size - params.k + 1);
+        size_t kmers_per_pattern = std::min((size_t) params.t, pattern_size - params.kmer.size() + 1);
 	    for (uint16_t matching_kmer_count{0}; matching_kmer_count < (uint16_t) std::round(params.t * information_content); matching_kmer_count++)
             {
                 if (fpr < precision) 

--- a/src/argument_parsing/build.cpp
+++ b/src/argument_parsing/build.cpp
@@ -101,7 +101,7 @@ void run_build(sharg::parser & parser)
 
         if (parser.is_option_set("kmer"))
         {
-            seqan3::debug_stream << "WARNING: kmer size k=" << arguments.kmer_size << " will be updated to " << search_profile.k 
+            seqan3::debug_stream << "WARNING: kmer size k=" << arguments.kmer_size << " will be updated to " << search_profile.kmer.size() 
                                  << ". Set --without-parameter-tuning to force manual input.";
         }
         if (parser.is_option_set("window"))
@@ -110,9 +110,9 @@ void run_build(sharg::parser & parser)
                                  << "Set --without-parameter-tuning to force manual input.";
         }
         
-        arguments.kmer_size = search_profile.k;
-        arguments.window_size = search_profile.k;
-        arguments.shape = search_profile.shape;
+        arguments.kmer_size = search_profile.kmer.size();
+        arguments.window_size = search_profile.kmer.size();
+        arguments.shape = search_profile.kmer.shape;
     }
     else
     {

--- a/src/argument_parsing/search.cpp
+++ b/src/argument_parsing/search.cpp
@@ -338,7 +338,8 @@ void run_search(sharg::parser & parser)
         arguments.search_type = error_profile.search_type;
         if (parser.is_option_set("threshold"))
         {
-            auto lemma_thresh = kmer_lemma_threshold(arguments.pattern_size, arguments.shape_weight, arguments.errors);
+            utilities::kmer kmer{arguments.shape};
+            auto lemma_thresh = kmer.lemma_threshold(arguments.pattern_size, arguments.errors);
             if (arguments.threshold > lemma_thresh)
                 arguments.search_type = search_kind::HEURISTIC;
             else 

--- a/src/threshold/find.cpp
+++ b/src/threshold/find.cpp
@@ -99,7 +99,7 @@ param_set get_best_params(search_pattern const & pattern,
 }
 
 /**
- * @brief For a chosen kmer size and up to some maximum error rate find the best thresholds. 
+ * @brief For a chosen kmer shape and up to some maximum error rate find the best thresholds. 
  *        Consider different error rates up to max_err.
 */
 search_kmer_profile find_thresholds_for_kmer_size(metadata const & ref_meta,
@@ -113,16 +113,16 @@ search_kmer_profile find_thresholds_for_kmer_size(metadata const & ref_meta,
         search_pattern pattern(errors, ref_meta.pattern_size);
         search_kind search_type{search_kind::LEMMA};
 
-        if (kmer_lemma_threshold(pattern.l, attr.k, errors) > space.max_thresh)
+        if (kmer_lemma_threshold(pattern.l, attr.kmer_weight, errors) > space.max_thresh)
         {
-            auto best_params = param_set(attr.k, kmer_lemma_threshold(pattern.l, attr.k, errors));
+            auto best_params = param_set(attr.shape, kmer_lemma_threshold(pattern.l, attr.kmer_weight, errors));
             double fnr{0}; // == attr.fnr_for_param_set(pattern, best_params)
             double fp_per_pattern = ref_meta.pattern_spurious_match_prob(best_params);
             kmer_thresh.add_error_rate(errors, {best_params, pattern, search_type, fnr, fp_per_pattern});
         }
         else
         {
-            auto best_params = param_set(attr.k, kmer_lemma_threshold(pattern.l, attr.k, errors), space);
+            auto best_params = param_set(attr.shape, kmer_lemma_threshold(pattern.l, attr.kmer_weight, errors), space);
             auto try_params = best_params;
             if ((best_params.t < THRESH_LOWER) ||  
                 segment_fpr(ref_meta.pattern_spurious_match_prob(best_params), PATTERNS_PER_SEGMENT) > FPR_UPPER)

--- a/src/valik_split.cpp
+++ b/src/valik_split.cpp
@@ -51,12 +51,12 @@ void valik_split(split_arguments & arguments)
         if (arguments.kmer_size == std::numeric_limits<uint8_t>::max())
         {
             auto best_params = get_best_params(pattern, meta, fn_attr, arguments.verbose);
-            arguments.kmer_size = best_params.k;
+            arguments.kmer_size = best_params.kmer.size();
             arguments.shape = seqan3::shape{seqan3::ungapped(arguments.kmer_size)};
             arguments.shape_str = std::string(arguments.kmer_size, '1');
             arguments.shape_weight = arguments.kmer_size;
         }
-        const kmer_loss & attr = fn_attr.get_kmer_loss(arguments.shape);
+        const kmer_loss & attr = fn_attr.get_kmer_loss(utilities::kmer{arguments.shape});
 
         search_kmer_profile search_profile = find_thresholds_for_kmer_size(meta, attr, arguments.errors);
         if (arguments.verbose)

--- a/test/api/utilities/threshold/basics_test.cpp
+++ b/test/api/utilities/threshold/basics_test.cpp
@@ -1,12 +1,12 @@
 #include <gtest/gtest.h>
 
 #include <utilities/threshold/basics.hpp>
+#include <utilities/threshold/kmer.hpp>
 
 TEST(kmer_occurrences, small)
 {
     uint8_t kmer_size = 4;
     uint64_t genome_len = 256 + kmer_size - 1;
-    double inf_cont = 1.0;
     EXPECT_EQ(valik::expected_kmer_occurrences(genome_len, kmer_size), 1.0);
 }
 
@@ -14,24 +14,23 @@ TEST(kmer_occurrences, human_genome)
 {
     uint64_t human_genome_len = 3e9;
     uint8_t kmer_size = 16;
-    double inf_cont = 1.0;
     EXPECT_LE(valik::expected_kmer_occurrences(human_genome_len, kmer_size), 1.0);
 }
 
 TEST(kmer_lemma, manual_test)
 {
     size_t l = 100;
-    uint8_t k = 10;
+    utilities::kmer k{10};
 
-    uint8_t shared_kmer_count = l - k + 1; // 91
+    uint8_t shared_kmer_count = l - k.size() + 1; // 91
     for (uint8_t e{0}; e < 9; e++)
-        EXPECT_EQ(valik::kmer_lemma_threshold(l, k, e), shared_kmer_count - k * e);
+        EXPECT_EQ(k.lemma_threshold(l, e), shared_kmer_count - k.size() * e);
 
     uint8_t e = 10;
-    EXPECT_EQ(valik::kmer_lemma_threshold(l, k, e), 0);
+    EXPECT_EQ(k.lemma_threshold(l, e), 0);
 
     l = 15;
-    EXPECT_EQ(valik::kmer_lemma_threshold(l, k, e), 0);
+    EXPECT_EQ(k.lemma_threshold(l, e), 0);
 }
 
 TEST(combinations, edge_cases)

--- a/test/api/utilities/threshold/param_set_test.cpp
+++ b/test/api/utilities/threshold/param_set_test.cpp
@@ -2,11 +2,11 @@
 
 #include <utilities/threshold/param_set.hpp>
 
-TEST(error_handling, kmer_size)
+TEST(ungapped_error_handling, kmer_size)
 {
     valik::param_space space;
     uint8_t thresh = 5;
-    uint8_t kmer_size = 8;
+    uint8_t kmer_size = 6;
     EXPECT_THROW({
         try
         {
@@ -14,12 +14,12 @@ TEST(error_handling, kmer_size)
         }
         catch( const std::runtime_error& e )
         {
-            EXPECT_STREQ( ("k=" + std::to_string(kmer_size) + " out of range [9, 23]").c_str(), e.what() );
+            EXPECT_STREQ( ("k=" + std::to_string(kmer_size) + " out of range [7, 23]").c_str(), e.what() );
             throw;
         }
     }, std::runtime_error );
 
-    kmer_size = 9;
+    kmer_size = 8;
     EXPECT_NO_THROW({
         valik::param_set(kmer_size, thresh, space);
     });
@@ -32,7 +32,50 @@ TEST(error_handling, kmer_size)
         }
         catch( const std::runtime_error& e )
         {
-            EXPECT_STREQ( ("k=" + std::to_string(kmer_size) + " out of range [9, 23]").c_str(), e.what() );
+            EXPECT_STREQ( ("k=" + std::to_string(kmer_size) + " out of range [7, 23]").c_str(), e.what() );
+            throw;
+        }
+    }, std::runtime_error );
+}
+
+TEST(gapped_error_handling, kmer_size)
+{
+    valik::param_space space;
+    uint8_t thresh = 5;
+    seqan3::shape s{seqan3::bin_literal{0b110101011}};
+    utilities::kmer shaped_kmer{s};
+    
+    EXPECT_THROW({
+        try
+        {
+            valik::param_set(shaped_kmer, thresh, space);
+        }
+        catch( const std::runtime_error& e )
+        {
+            EXPECT_STREQ( ("k=" + std::to_string(shaped_kmer.weight()) + " out of range [7, 23]").c_str(), e.what() );
+            throw;
+        }
+    }, std::runtime_error );
+
+    shaped_kmer = seqan3::shape{seqan3::bin_literal{0b1101010111}};
+    EXPECT_NO_THROW({
+        valik::param_set(shaped_kmer, thresh, space);
+    });
+
+    shaped_kmer = seqan3::shape{seqan3::bin_literal{0b111000000001010000000001111}};
+    EXPECT_NO_THROW({
+        valik::param_set(shaped_kmer, thresh, space);
+    });
+
+    shaped_kmer = seqan3::shape{seqan3::bin_literal{0b1111111100011110111100011111111}};
+    EXPECT_THROW({
+        try
+        {
+            valik::param_set(shaped_kmer, thresh, space);
+        }
+        catch( const std::runtime_error& e )
+        {
+            EXPECT_STREQ( ("k=" + std::to_string(shaped_kmer.weight()) + " out of range [7, 23]").c_str(), e.what() );
             throw;
         }
     }, std::runtime_error );

--- a/test/cli/dream_test.cpp
+++ b/test/cli/dream_test.cpp
@@ -166,3 +166,63 @@ INSTANTIATE_TEST_SUITE_P(split_shared_memory_dream_suite,
                              std::string name = std::to_string(std::get<0>(info.param)) + "_error";
                              return name;
                          });
+
+
+TEST_P(dream_split_search, split_shaped_kmer)
+{
+    auto const [number_of_errors] = GetParam();
+    size_t pattern_size = 50;
+    float error_rate = (float) number_of_errors / (float) pattern_size;
+    float max_error_rate = 0.04;
+
+    setup_tmp_dir();
+    setenv("VALIK_MERGE", "cat", true);
+
+    std::filesystem::path ref_meta_path = "ref_meta.bin";
+    std::filesystem::path index_path = "index.ibf";
+
+    cli_test_result const split_ref = execute_app("valik", "split",
+                                                           data("ref.fasta"),
+                                                           "--fpr 0.001",
+                                                           "--shape 1111110110110111111",
+                                                           "--out", ref_meta_path,
+                                                           "--pattern ", std::to_string(pattern_size), 
+                                                           "--error-rate ", std::to_string(max_error_rate));
+    EXPECT_EQ(split_ref.exit_code, 0);
+    EXPECT_EQ(split_ref.err, std::string{});
+    valik::metadata reference(ref_meta_path);
+
+    cli_test_result const build = execute_app("valik", "build",
+                                                       "--ref-meta", ref_meta_path,
+                                                       "--output ", index_path);
+    EXPECT_EQ(build.exit_code, 0);
+
+    cli_test_result const search = execute_app("valik", "search",
+                                                        "--output search.gff",
+                                                        "--split-query",
+                                                        "--error-rate ", std::to_string(error_rate),
+                                                        "--index ", index_path,
+                                                        "--query ", data("query.fasta"),
+                                                        "--ref-meta", ref_meta_path,
+                                                        "--repeatPeriod 1",
+                                                        "--repeatLength 10", 
+                                                        "--numMatches 2");
+
+    EXPECT_EQ(search.exit_code, 0);
+    EXPECT_EQ(search.out, std::string{"Launching stellar search on a shared memory machine...\nLoaded 4 database sequences.\n"});
+    EXPECT_EQ(search.err, std::string{});
+
+    auto distributed = valik::read_alignment_output<valik::stellar_match>(search_result_path(number_of_errors), reference, std::ios::binary);
+    auto local = valik::read_alignment_output<valik::stellar_match>("search.gff", reference);
+    
+    compare_gff_out(distributed, local);
+}
+
+INSTANTIATE_TEST_SUITE_P(split_shared_memory_gapped_dream_suite,
+                         dream_split_search,
+                         testing::Combine(testing::Values(1, 2)),
+                         [] (testing::TestParamInfo<dream_split_search::ParamType> const & info)
+                         {
+                             std::string name = std::to_string(std::get<0>(info.param)) + "_error";
+                             return name;
+                         });


### PR DESCRIPTION
Find the FNR and FPR estimates for gapped k-mers to find suitable thresholds. For FNR the effective length of a gapped k-mer is the length of ungapped triplets. For FPR the effective length is the total weight of the k-mer. 